### PR TITLE
Add dept-devops to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,3 +5,6 @@
 # The following owners will be the default owners for everything in the repo.
 # Unless a later match takes precedence
 * @bitwarden/team-auth-dev
+
+# DevOps for Actions and other workflow changes.
+.github/workflows @bitwarden/dept-devops


### PR DESCRIPTION
Adds @bitwarden/dept-devops as code owners for the `.github/workflows` directory.