### PR TITLE
[PM-35442] Key connector not updating key via PUT

### DIFF
--- a/src/KeyConnector/Controllers/UserKeysController.cs
+++ b/src/KeyConnector/Controllers/UserKeysController.cs
@@ -76,11 +76,19 @@ namespace Bit.KeyConnector.Controllers
             var user = await _userKeyRepository.ReadAsync(userId);
             if (user == null)
             {
-                return new NotFoundResult();
+                user = new UserKeyModel
+                {
+                    Id = userId,
+                    Key = await _cryptoService.AesEncryptToB64Async(model.Key)
+                };
+                await _userKeyRepository.CreateAsync(user);
             }
-            user.Key = await _cryptoService.AesEncryptToB64Async(model.Key);
-            user.RevisionDate = DateTime.UtcNow;
-            await _userKeyRepository.UpdateAsync(user);
+            else
+            {
+                user.Key = await _cryptoService.AesEncryptToB64Async(model.Key);
+                user.RevisionDate = DateTime.UtcNow;
+                await _userKeyRepository.UpdateAsync(user);
+            }
             return new OkResult();
         }
 

--- a/src/KeyConnector/Controllers/UserKeysController.cs
+++ b/src/KeyConnector/Controllers/UserKeysController.cs
@@ -74,15 +74,12 @@ namespace Bit.KeyConnector.Controllers
         {
             var userId = GetProperUserId().Value;
             var user = await _userKeyRepository.ReadAsync(userId);
-            if (user != null)
+            if (user == null)
             {
-                return new BadRequestResult();
+                return new NotFoundResult();
             }
-            user = new UserKeyModel
-            {
-                Id = userId,
-                Key = await _cryptoService.AesEncryptToB64Async(model.Key)
-            };
+            user.Key = await _cryptoService.AesEncryptToB64Async(model.Key);
+            user.RevisionDate = DateTime.UtcNow;
             await _userKeyRepository.UpdateAsync(user);
             return new OkResult();
         }

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading.Tasks;
+using Bit.KeyConnector.Models;
+using Bit.KeyConnector.Repositories;
+using Bit.KeyConnector.Services;
+using KeyConnector.Tests.Helpers;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace KeyConnector.Tests.Controllers;
+
+public class UserKeysControllerIntegrationTests : IClassFixture<KeyConnectorWebApplicationFactory>
+{
+    private readonly HttpClient _client;
+    private readonly IUserKeyRepository _userKeyRepository;
+    private readonly ICryptoService _cryptoService;
+
+    public UserKeysControllerIntegrationTests(KeyConnectorWebApplicationFactory factory)
+    {
+        _client = factory.CreateClient();
+        var scope = factory.Services;
+        _userKeyRepository = scope.GetRequiredService<IUserKeyRepository>();
+        _cryptoService = scope.GetRequiredService<ICryptoService>();
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_WhenUserDoesNotExist()
+    {
+        var request = CreateRequest(HttpMethod.Get, Guid.NewGuid());
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsDecryptedKey_WhenUserExistsInDatabase()
+    {
+        var userId = Guid.NewGuid();
+        var plainKey = GenerateBase64Key("direct-insert-key");
+        var encryptedKey = await _cryptoService.AesEncryptToB64Async(plainKey);
+        await _userKeyRepository.CreateAsync(new UserKeyModel { Id = userId, Key = encryptedKey });
+
+        var request = CreateRequest(HttpMethod.Get, userId);
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<UserKeyResponseModel>();
+        Assert.Equal(plainKey, result.Key);
+    }
+
+    [Fact]
+    public async Task Post_ThenGet_RoundTripsKey()
+    {
+        var userId = Guid.NewGuid();
+        var key = GenerateBase64Key("test-key-value");
+        var beforePost = DateTime.UtcNow;
+
+        var postRequest = CreateRequest(HttpMethod.Post, userId, new { Key = key });
+        var postResponse = await _client.SendAsync(postRequest);
+        Assert.Equal(HttpStatusCode.OK, postResponse.StatusCode);
+
+        var getRequest = CreateRequest(HttpMethod.Get, userId);
+        var getResponse = await _client.SendAsync(getRequest);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var result = await getResponse.Content.ReadFromJsonAsync<UserKeyResponseModel>();
+        Assert.Equal(key, result.Key);
+
+        var stored = await _userKeyRepository.ReadAsync(userId);
+        Assert.InRange(stored.CreationDate, beforePost, DateTime.UtcNow);
+    }
+
+    [Fact]
+    public async Task Post_ReturnsBadRequest_WhenUserAlreadyExists()
+    {
+        var userId = Guid.NewGuid();
+
+        var postRequest = CreateRequest(HttpMethod.Post, userId, new { Key = GenerateBase64Key("key1") });
+        await _client.SendAsync(postRequest);
+
+        var duplicateRequest = CreateRequest(HttpMethod.Post, userId, new { Key = GenerateBase64Key("key2") });
+        var response = await _client.SendAsync(duplicateRequest);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_ReturnsNotFound_WhenUserDoesNotExist()
+    {
+        var request = CreateRequest(HttpMethod.Put, Guid.NewGuid(), new { Key = GenerateBase64Key("key") });
+
+        var response = await _client.SendAsync(request);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Put_UpdatesKey_ThenGetReturnsUpdatedKey()
+    {
+        var userId = Guid.NewGuid();
+
+        var originalKey = GenerateBase64Key("original-key");
+        var updatedKey = GenerateBase64Key("updated-key");
+
+        var postRequest = CreateRequest(HttpMethod.Post, userId, new { Key = originalKey });
+        await _client.SendAsync(postRequest);
+
+        var beforePut = DateTime.UtcNow;
+        var putRequest = CreateRequest(HttpMethod.Put, userId, new { Key = updatedKey });
+        var putResponse = await _client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
+
+        var getRequest = CreateRequest(HttpMethod.Get, userId);
+        var getResponse = await _client.SendAsync(getRequest);
+        var result = await getResponse.Content.ReadFromJsonAsync<UserKeyResponseModel>();
+        Assert.Equal(updatedKey, result.Key);
+
+        var stored = await _userKeyRepository.ReadAsync(userId);
+        Assert.NotNull(stored.RevisionDate);
+        Assert.InRange(stored.RevisionDate.Value, beforePut, DateTime.UtcNow);
+    }
+
+    private static string GenerateBase64Key(string label) =>
+        Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(label));
+
+    private HttpRequestMessage CreateRequest(HttpMethod method, Guid userId, object body = null)
+    {
+        var request = new HttpRequestMessage(method, "/user-keys");
+        request.Headers.Add(TestAuthHandler.TestUserIdHeader, userId.ToString());
+        if (body != null)
+        {
+            request.Content = JsonContent.Create(body);
+        }
+        return request;
+    }
+}

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
@@ -89,13 +89,25 @@ public class UserKeysControllerIntegrationTests : IClassFixture<KeyConnectorWebA
     }
 
     [Fact]
-    public async Task Put_ReturnsNotFound_WhenUserDoesNotExist()
+    public async Task Put_CreatesUser_WhenUserDoesNotExist()
     {
-        var request = CreateRequest(HttpMethod.Put, Guid.NewGuid(), new { Key = GenerateBase64Key("key") });
+        var userId = Guid.NewGuid();
+        var key = GenerateBase64Key("put-create-key");
+        var beforePut = DateTime.UtcNow;
 
-        var response = await _client.SendAsync(request);
+        var putRequest = CreateRequest(HttpMethod.Put, userId, new { Key = key });
+        var putResponse = await _client.SendAsync(putRequest);
+        Assert.Equal(HttpStatusCode.OK, putResponse.StatusCode);
 
-        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+        var getRequest = CreateRequest(HttpMethod.Get, userId);
+        var getResponse = await _client.SendAsync(getRequest);
+        Assert.Equal(HttpStatusCode.OK, getResponse.StatusCode);
+
+        var result = await getResponse.Content.ReadFromJsonAsync<UserKeyResponseModel>();
+        Assert.Equal(key, result.Key);
+
+        var stored = await _userKeyRepository.ReadAsync(userId);
+        Assert.InRange(stored.CreationDate, beforePut, DateTime.UtcNow);
     }
 
     [Fact]

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Security.Claims;
+using System.Threading.Tasks;
+using Bit.KeyConnector.Controllers;
+using Bit.KeyConnector.Models;
+using Bit.KeyConnector.Repositories;
+using Bit.KeyConnector.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace KeyConnector.Tests.Controllers;
+
+public class UserKeysControllerTests
+{
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly IUserKeyRepository _userKeyRepository = Substitute.For<IUserKeyRepository>();
+    private readonly ICryptoService _cryptoService = Substitute.For<ICryptoService>();
+    private readonly UserKeysController _sut;
+
+    public UserKeysControllerTests()
+    {
+        var identityOptions = new IdentityOptions();
+        var logger = Substitute.For<ILogger<UserKeysController>>();
+
+        _sut = new UserKeysController(
+            Options.Create(identityOptions),
+            logger,
+            _userKeyRepository,
+            _cryptoService);
+
+        var claims = new ClaimsPrincipal(new ClaimsIdentity(
+        [
+            new Claim(identityOptions.ClaimsIdentity.UserIdClaimType, _userId.ToString())
+        ]));
+        _sut.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext { User = claims }
+        };
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_WhenUserDoesNotExist()
+    {
+        _userKeyRepository.ReadAsync(_userId).Returns((UserKeyModel)null);
+
+        var result = await _sut.Get();
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsDecryptedKey_WhenUserExists()
+    {
+        var user = new UserKeyModel { Id = _userId, Key = "encryptedKey" };
+        _userKeyRepository.ReadAsync(_userId).Returns(user);
+        _cryptoService.AesDecryptToB64Async("encryptedKey").Returns("decryptedKey");
+
+        var result = await _sut.Get();
+
+        var jsonResult = Assert.IsType<JsonResult>(result);
+        var response = Assert.IsType<UserKeyResponseModel>(jsonResult.Value);
+        Assert.Equal("decryptedKey", response.Key);
+    }
+
+    [Fact]
+    public async Task Get_UpdatesLastAccessDate_WhenUserExists()
+    {
+        var user = new UserKeyModel { Id = _userId, Key = "encryptedKey" };
+        _userKeyRepository.ReadAsync(_userId).Returns(user);
+        _cryptoService.AesDecryptToB64Async("encryptedKey").Returns("decryptedKey");
+        var beforeGet = DateTime.UtcNow;
+
+        await _sut.Get();
+
+        Assert.NotNull(user.LastAccessDate);
+        Assert.InRange(user.LastAccessDate.Value, beforeGet, DateTime.UtcNow);
+        await _userKeyRepository.Received(1).UpdateAsync(user);
+    }
+
+    [Fact]
+    public async Task Post_ReturnsBadRequest_WhenUserAlreadyExists()
+    {
+        var existingUser = new UserKeyModel { Id = _userId, Key = "existingKey" };
+        _userKeyRepository.ReadAsync(_userId).Returns(existingUser);
+
+        var result = await _sut.Post(new UserKeyRequestModel { Key = "newKey" });
+
+        Assert.IsType<BadRequestResult>(result);
+        await _userKeyRepository.DidNotReceive().CreateAsync(Arg.Any<UserKeyModel>());
+    }
+
+    [Fact]
+    public async Task Post_CreatesUser_WhenUserDoesNotExist()
+    {
+        _userKeyRepository.ReadAsync(_userId).Returns((UserKeyModel)null);
+        _cryptoService.AesEncryptToB64Async("plaintextKey").Returns("encryptedKey");
+        UserKeyModel capturedUser = null;
+        await _userKeyRepository.CreateAsync(Arg.Do<UserKeyModel>(u => capturedUser = u));
+        var beforeCreate = DateTime.UtcNow;
+
+        var result = await _sut.Post(new UserKeyRequestModel { Key = "plaintextKey" });
+
+        Assert.IsType<OkResult>(result);
+        Assert.NotNull(capturedUser);
+        Assert.Equal(_userId, capturedUser.Id);
+        Assert.Equal("encryptedKey", capturedUser.Key);
+        Assert.InRange(capturedUser.CreationDate, beforeCreate, DateTime.UtcNow);
+        await _userKeyRepository.Received(1).CreateAsync(capturedUser);
+    }
+
+    [Fact]
+    public async Task Put_ReturnsNotFound_WhenUserDoesNotExist()
+    {
+        _userKeyRepository.ReadAsync(_userId).Returns((UserKeyModel)null);
+
+        var result = await _sut.Put(new UserKeyRequestModel { Key = "newKey" });
+
+        Assert.IsType<NotFoundResult>(result);
+        await _userKeyRepository.DidNotReceive().UpdateAsync(Arg.Any<UserKeyModel>());
+    }
+
+    [Fact]
+    public async Task Put_UpdatesKey_WhenUserExists()
+    {
+        var creationDate = DateTime.UtcNow.AddDays(-1);
+        var existingUser = new UserKeyModel
+        {
+            Id = _userId, Key = "oldEncryptedKey", CreationDate = creationDate
+        };
+        _userKeyRepository.ReadAsync(_userId).Returns(existingUser);
+        _cryptoService.AesEncryptToB64Async("newPlaintextKey").Returns("newEncryptedKey");
+        var beforeUpdate = DateTime.UtcNow;
+
+        var result = await _sut.Put(new UserKeyRequestModel { Key = "newPlaintextKey" });
+
+        Assert.IsType<OkResult>(result);
+        Assert.Equal(_userId, existingUser.Id);
+        Assert.Equal("newEncryptedKey", existingUser.Key);
+        Assert.Equal(creationDate, existingUser.CreationDate);
+        Assert.NotNull(existingUser.RevisionDate);
+        Assert.InRange(existingUser.RevisionDate.Value, beforeUpdate, DateTime.UtcNow);
+        await _userKeyRepository.Received(1).UpdateAsync(existingUser);
+    }
+}

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
@@ -114,13 +114,22 @@ public class UserKeysControllerTests
     }
 
     [Fact]
-    public async Task Put_ReturnsNotFound_WhenUserDoesNotExist()
+    public async Task Put_CreatesUser_WhenUserDoesNotExist()
     {
         _userKeyRepository.ReadAsync(_userId).Returns((UserKeyModel)null);
+        _cryptoService.AesEncryptToB64Async("newKey").Returns("encryptedNewKey");
+        UserKeyModel capturedUser = null;
+        await _userKeyRepository.CreateAsync(Arg.Do<UserKeyModel>(u => capturedUser = u));
+        var beforeCreate = DateTime.UtcNow;
 
         var result = await _sut.Put(new UserKeyRequestModel { Key = "newKey" });
 
-        Assert.IsType<NotFoundResult>(result);
+        Assert.IsType<OkResult>(result);
+        Assert.NotNull(capturedUser);
+        Assert.Equal(_userId, capturedUser.Id);
+        Assert.Equal("encryptedNewKey", capturedUser.Key);
+        Assert.InRange(capturedUser.CreationDate, beforeCreate, DateTime.UtcNow);
+        await _userKeyRepository.Received(1).CreateAsync(capturedUser);
         await _userKeyRepository.DidNotReceive().UpdateAsync(Arg.Any<UserKeyModel>());
     }
 
@@ -147,5 +156,6 @@ public class UserKeysControllerTests
         Assert.NotNull(existingUser.RevisionDate);
         Assert.InRange(existingUser.RevisionDate.Value, beforeUpdate, DateTime.UtcNow);
         await _userKeyRepository.Received(1).UpdateAsync(existingUser);
+        await _userKeyRepository.DidNotReceive().CreateAsync(Arg.Any<UserKeyModel>());
     }
 }

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
@@ -130,7 +130,9 @@ public class UserKeysControllerTests
         var creationDate = DateTime.UtcNow.AddDays(-1);
         var existingUser = new UserKeyModel
         {
-            Id = _userId, Key = "oldEncryptedKey", CreationDate = creationDate
+            Id = _userId,
+            Key = "oldEncryptedKey",
+            CreationDate = creationDate
         };
         _userKeyRepository.ReadAsync(_userId).Returns(existingUser);
         _cryptoService.AesEncryptToB64Async("newPlaintextKey").Returns("newEncryptedKey");

--- a/test/KeyConnector.Tests/Helpers/KeyConnectorWebApplicationFactory.cs
+++ b/test/KeyConnector.Tests/Helpers/KeyConnectorWebApplicationFactory.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using Bit.KeyConnector;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace KeyConnector.Tests.Helpers;
+
+public class KeyConnectorWebApplicationFactory : WebApplicationFactory<Startup>
+{
+    private readonly string _tempDir;
+    private readonly string _pfxPath;
+    private readonly string _dbPath;
+    private const string PfxPassword = "test";
+
+    public KeyConnectorWebApplicationFactory()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"kc-test-{Guid.NewGuid()}");
+        Directory.CreateDirectory(_tempDir);
+
+        _pfxPath = Path.Combine(_tempDir, "test.pfx");
+        _dbPath = Path.Combine(_tempDir, "database.db");
+
+        using var rsa = RSA.Create(2048);
+        var req = new CertificateRequest("CN=KeyConnectorTest", rsa, HashAlgorithmName.SHA256,
+            RSASignaturePadding.Pkcs1);
+        using var cert = req.CreateSelfSigned(DateTimeOffset.UtcNow, DateTimeOffset.UtcNow.AddYears(1));
+        File.WriteAllBytes(_pfxPath, cert.Export(X509ContentType.Pfx, PfxPassword));
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.UseEnvironment("Development");
+
+        builder.ConfigureAppConfiguration((_, config) =>
+        {
+            config.AddInMemoryCollection(new Dictionary<string, string>
+            {
+                ["keyConnectorSettings:database:provider"] = "sqlite",
+                ["keyConnectorSettings:database:sqliteConnectionString"] = $"Data Source={_dbPath}",
+                ["keyConnectorSettings:rsaKey:provider"] = "certificate",
+                ["keyConnectorSettings:certificate:provider"] = "filesystem",
+                ["keyConnectorSettings:certificate:filesystemPath"] = _pfxPath,
+                ["keyConnectorSettings:certificate:filesystemPassword"] = PfxPassword,
+                ["keyConnectorSettings:identityServerUri"] = "http://localhost",
+                ["keyConnectorSettings:webVaultUri"] = "http://localhost",
+            });
+        });
+
+        builder.ConfigureTestServices(services =>
+        {
+            services.AddAuthentication(options =>
+                {
+                    options.DefaultAuthenticateScheme = "TestScheme";
+                    options.DefaultChallengeScheme = "TestScheme";
+                })
+                .AddScheme<AuthenticationSchemeOptions, TestAuthHandler>("TestScheme", _ => { });
+        });
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        if (disposing && Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, true);
+        }
+    }
+}

--- a/test/KeyConnector.Tests/Helpers/TestAuthHandler.cs
+++ b/test/KeyConnector.Tests/Helpers/TestAuthHandler.cs
@@ -1,0 +1,40 @@
+﻿using System.Security.Claims;
+using System.Text.Encodings.Web;
+using System.Threading.Tasks;
+using IdentityModel;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace KeyConnector.Tests.Helpers;
+
+public class TestAuthHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+{
+    public const string TestUserIdHeader = "X-Test-UserId";
+
+    public TestAuthHandler(
+        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        ILoggerFactory logger,
+        UrlEncoder encoder)
+        : base(options, logger, encoder) { }
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var userId = Request.Headers[TestUserIdHeader].ToString();
+        if (string.IsNullOrEmpty(userId))
+        {
+            return Task.FromResult(AuthenticateResult.Fail("Missing test user ID header"));
+        }
+
+        var claims = new[]
+        {
+            new Claim(JwtClaimTypes.Subject, userId),
+            new Claim(JwtClaimTypes.AuthenticationMethod, "Application"),
+            new Claim(JwtClaimTypes.Scope, "api"),
+        };
+        var identity = new ClaimsIdentity(claims, "TestScheme");
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, "TestScheme");
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/test/KeyConnector.Tests/KeyConnector.Tests.csproj
+++ b/test/KeyConnector.Tests/KeyConnector.Tests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.10.0]" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="[8.0.0]" />
     <PackageReference Include="NSubstitute" Version="[5.1.0]" />
     <PackageReference Include="xunit" Version="[2.8.1]" />
     <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.2]">


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-35442

## 📔 Objective

`PUT /key-connector/user-keys` rejects the request if the user already have the key in database - this PR fixes this bug.
Also adds unit tests and integration test coverage.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
