### PR TITLE
[PM-38500] Functional services grouping and re-organization

### DIFF
--- a/src/KeyConnector/Controllers/UserKeysController.cs
+++ b/src/KeyConnector/Controllers/UserKeysController.cs
@@ -3,7 +3,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Bit.KeyConnector.Models;
 using Bit.KeyConnector.Repositories;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.Crypto;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;

--- a/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
+++ b/src/KeyConnector/Exceptions/InvalidKeyTypeException.cs
@@ -1,5 +1,4 @@
-using System;
-using System.Runtime.Serialization;
+﻿using System;
 
 namespace Bit.KeyConnector.Exceptions
 {

--- a/src/KeyConnector/HostedServices/TransferToHostedService.cs
+++ b/src/KeyConnector/HostedServices/TransferToHostedService.cs
@@ -4,7 +4,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Bit.KeyConnector.Repositories;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.Crypto;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;

--- a/src/KeyConnector/Repositories/Mongo/UserKeyRepository.cs
+++ b/src/KeyConnector/Repositories/Mongo/UserKeyRepository.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections;
 using System.Threading.Tasks;
 using Bit.KeyConnector.Models;
-using JsonFlatFileDataStore;
 using MongoDB.Driver;
 
 namespace Bit.KeyConnector.Repositories.Mongo

--- a/src/KeyConnector/ServiceCollectionExtensions.cs
+++ b/src/KeyConnector/ServiceCollectionExtensions.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Security.Claims;
 using Bit.KeyConnector.Repositories;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.CertificateProviders;
+using Bit.KeyConnector.Services.Crypto;
 using Bit.KeyConnector.Services.Pkcs11;
+using Bit.KeyConnector.Services.RsaKey;
 using IdentityModel;
 using IdentityServer4.AccessTokenValidation;
 using JsonFlatFileDataStore;

--- a/src/KeyConnector/Services/CertificateProviders/AzureKeyVaultCertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/AzureKeyVaultCertificateProviderService.cs
@@ -5,7 +5,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Secrets;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public class AzureKeyVaultCertificateProviderService : ICertificateProviderService
     {

--- a/src/KeyConnector/Services/CertificateProviders/AzureStorageCertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/AzureStorageCertificateProviderService.cs
@@ -3,7 +3,7 @@ using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 using Azure.Storage.Blobs;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public class AzureStorageCertificateProviderService : ICertificateProviderService
     {

--- a/src/KeyConnector/Services/CertificateProviders/FilesystemCertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/FilesystemCertificateProviderService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public class FilesystemCertificateProviderService : ICertificateProviderService
     {

--- a/src/KeyConnector/Services/CertificateProviders/HashicorpVaultCertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/HashicorpVaultCertificateProviderService.cs
@@ -5,7 +5,7 @@ using Microsoft.Extensions.Logging;
 using VaultSharp;
 using VaultSharp.V1.AuthMethods.Token;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public class HashicorpVaultCertificateProviderService : ICertificateProviderService
     {

--- a/src/KeyConnector/Services/CertificateProviders/ICertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/ICertificateProviderService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public interface ICertificateProviderService
     {

--- a/src/KeyConnector/Services/CertificateProviders/StoreCertificateProviderService.cs
+++ b/src/KeyConnector/Services/CertificateProviders/StoreCertificateProviderService.cs
@@ -2,7 +2,7 @@
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.CertificateProviders
 {
     public class StoreCertificateProviderService : ICertificateProviderService
     {

--- a/src/KeyConnector/Services/Crypto/CryptoFunctionService.cs
+++ b/src/KeyConnector/Services/Crypto/CryptoFunctionService.cs
@@ -2,7 +2,7 @@
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.Crypto
 {
     public class CryptoFunctionService : ICryptoFunctionService
     {

--- a/src/KeyConnector/Services/Crypto/CryptoService.cs
+++ b/src/KeyConnector/Services/Crypto/CryptoService.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Bit.KeyConnector.Repositories;
+using Bit.KeyConnector.Services.RsaKey;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.Crypto
 {
     public class CryptoService : ICryptoService
     {

--- a/src/KeyConnector/Services/Crypto/ICryptoFunctionService.cs
+++ b/src/KeyConnector/Services/Crypto/ICryptoFunctionService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Security.Cryptography;
 using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.Crypto
 {
     public interface ICryptoFunctionService
     {

--- a/src/KeyConnector/Services/Crypto/ICryptoService.cs
+++ b/src/KeyConnector/Services/Crypto/ICryptoService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.Crypto
 {
     public interface ICryptoService
     {

--- a/src/KeyConnector/Services/Pkcs11/IPkcs11InteropFactory.cs
+++ b/src/KeyConnector/Services/Pkcs11/IPkcs11InteropFactory.cs
@@ -1,4 +1,4 @@
-using Net.Pkcs11Interop.Common;
+﻿using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.Factories;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;

--- a/src/KeyConnector/Services/Pkcs11/Pkcs11InteropFactory.cs
+++ b/src/KeyConnector/Services/Pkcs11/Pkcs11InteropFactory.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using Net.Pkcs11Interop.Common;
@@ -9,9 +9,9 @@ namespace Bit.KeyConnector.Services.Pkcs11;
 
 public class Pkcs11InteropFactory : IPkcs11InteropFactory
 {
-   private readonly Pkcs11InteropFactories _factories;
+    private readonly Pkcs11InteropFactories _factories;
 
-   public Pkcs11InteropFactory()
+    public Pkcs11InteropFactory()
     {
         if (Platform.IsLinux)
         {
@@ -25,17 +25,17 @@ public class Pkcs11InteropFactory : IPkcs11InteropFactory
     {
         return _factories.Pkcs11LibraryFactory.LoadPkcs11Library(_factories, libraryPath, appType);
     }
-    
+
     public ICkRsaPkcsOaepParams CreateCkRsaPkcsOaepParams(ulong hashAlg, ulong mgf, ulong source, byte[] sourceData)
     {
         return _factories.MechanismParamsFactory.CreateCkRsaPkcsOaepParams(hashAlg, mgf, source, sourceData);
     }
-    
+
     public IMechanism CreateMechanism(CKM type)
     {
         return _factories.MechanismFactory.Create(type);
     }
-    
+
     public IMechanism CreateMechanism(CKM type, IMechanismParams parameters)
     {
         return _factories.MechanismFactory.Create(type, parameters);
@@ -50,12 +50,12 @@ public class Pkcs11InteropFactory : IPkcs11InteropFactory
     {
         return _factories.ObjectAttributeFactory.Create(type, value);
     }
-    
+
     public IObjectAttribute CreateObjectAttribute(CKA type, ulong value)
     {
         return _factories.ObjectAttributeFactory.Create(type, value);
     }
-    
+
     public IObjectAttribute CreateObjectAttribute(CKA type, string value)
     {
         return _factories.ObjectAttributeFactory.Create(type, value);

--- a/src/KeyConnector/Services/RsaKey/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/AwsKmsRsaKeyService.cs
@@ -17,10 +17,12 @@ namespace Bit.KeyConnector.Services.RsaKey
             KeyConnectorSettings settings)
         {
             _settings = settings;
-            if(UseInstanceMetadataForCredentials())
+            if (UseInstanceMetadataForCredentials())
             {
                 _kmsClient = new AmazonKeyManagementServiceClient(RegionEndpoint.GetBySystemName(settings.RsaKey.AwsRegion));
-            } else {
+            }
+            else
+            {
                 _kmsClient = new AmazonKeyManagementServiceClient(settings.RsaKey.AwsAccessKeyId, settings.RsaKey.AwsAccessKeySecret, RegionEndpoint.GetBySystemName(settings.RsaKey.AwsRegion));
             }
         }

--- a/src/KeyConnector/Services/RsaKey/AwsKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/AwsKmsRsaKeyService.cs
@@ -6,7 +6,7 @@ using Amazon.KeyManagementService;
 using Amazon.KeyManagementService.Model;
 using Bit.KeyConnector.Exceptions;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class AwsKmsRsaKeyService : IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/AzureKeyVaultRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/AzureKeyVaultRsaKeyService.cs
@@ -4,7 +4,7 @@ using Azure.Identity;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class AzureKeyVaultRsaKeyService : IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/GoogleCloudKmsRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/GoogleCloudKmsRsaKeyService.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Google.Cloud.Kms.V1;
 using Google.Protobuf;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class GoogleCloudKmsRsaKeyService : IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/IRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/IRsaKeyService.cs
@@ -1,6 +1,6 @@
 ﻿using System.Threading.Tasks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public interface IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/LocalCertificateRsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/LocalCertificateRsaKeyService.cs
@@ -1,7 +1,9 @@
 ﻿using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Bit.KeyConnector.Services.CertificateProviders;
+using Bit.KeyConnector.Services.Crypto;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class LocalCertificateRsaKeyService : IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/Pkcs11RsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/Pkcs11RsaKeyService.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
+using Bit.KeyConnector.Services.CertificateProviders;
+using Bit.KeyConnector.Services.Crypto;
+using Bit.KeyConnector.Services.Pkcs11;
 using Net.Pkcs11Interop.Common;
 using Net.Pkcs11Interop.HighLevelAPI;
 
-namespace Bit.KeyConnector.Services.Pkcs11
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class Pkcs11RsaKeyService : IRsaKeyService
     {

--- a/src/KeyConnector/Services/RsaKey/Pkcs11RsaKeyService.cs
+++ b/src/KeyConnector/Services/RsaKey/Pkcs11RsaKeyService.cs
@@ -184,7 +184,7 @@ namespace Bit.KeyConnector.Services.RsaKey
                         break;
                     }
                 }
-                catch (Pkcs11Exception) {}
+                catch (Pkcs11Exception) { }
             }
 
             if (chosenSlot == null)

--- a/src/KeyConnector/Services/RsaKey/RsaHealthCheckService.cs
+++ b/src/KeyConnector/Services/RsaKey/RsaHealthCheckService.cs
@@ -2,7 +2,7 @@
 using System.Threading.Tasks;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
-namespace Bit.KeyConnector.Services
+namespace Bit.KeyConnector.Services.RsaKey
 {
     public class RsaHealthCheckService : IHealthCheck
     {

--- a/src/KeyConnector/Startup.cs
+++ b/src/KeyConnector/Startup.cs
@@ -1,5 +1,5 @@
 ﻿using System.Globalization;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.RsaKey;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerIntegrationTests.cs
@@ -5,7 +5,7 @@ using System.Net.Http.Json;
 using System.Threading.Tasks;
 using Bit.KeyConnector.Models;
 using Bit.KeyConnector.Repositories;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.Crypto;
 using KeyConnector.Tests.Helpers;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;

--- a/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
+++ b/test/KeyConnector.Tests/Controllers/UserKeysControllerTests.cs
@@ -4,7 +4,7 @@ using System.Threading.Tasks;
 using Bit.KeyConnector.Controllers;
 using Bit.KeyConnector.Models;
 using Bit.KeyConnector.Repositories;
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.Crypto;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;

--- a/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
+++ b/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
@@ -14,7 +14,7 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 
-namespace KeyConnector.Tests.Services;
+namespace KeyConnector.Tests.Services.RsaKey;
 
 internal delegate void InitializationModifier(
     ICertificateProviderService certificateProviderService,

--- a/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
+++ b/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
@@ -1,4 +1,7 @@
-using Bit.KeyConnector.Services;
+using Bit.KeyConnector.Services.CertificateProviders;
+using Bit.KeyConnector.Services.Crypto;
+using Bit.KeyConnector.Services.Pkcs11;
+using Bit.KeyConnector.Services.RsaKey;
 using Xunit;
 using NSubstitute;
 using Bit.KeyConnector;
@@ -9,7 +12,6 @@ using System;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
-using Bit.KeyConnector.Services.Pkcs11;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
 
 namespace KeyConnector.Tests.Services;

--- a/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
+++ b/test/KeyConnector.Tests/Services/RsaKey/Pkcs11RsaKeyServiceTests.cs
@@ -1,18 +1,18 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using Bit.KeyConnector;
 using Bit.KeyConnector.Services.CertificateProviders;
 using Bit.KeyConnector.Services.Crypto;
 using Bit.KeyConnector.Services.Pkcs11;
 using Bit.KeyConnector.Services.RsaKey;
-using Xunit;
-using NSubstitute;
-using Bit.KeyConnector;
-using System.Threading.Tasks;
-using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.Common;
-using System;
-using System.Linq;
-using System.Security.Cryptography;
-using System.Security.Cryptography.X509Certificates;
+using Net.Pkcs11Interop.HighLevelAPI;
 using Net.Pkcs11Interop.HighLevelAPI.MechanismParams;
+using NSubstitute;
+using Xunit;
 
 namespace KeyConnector.Tests.Services.RsaKey;
 
@@ -41,7 +41,7 @@ public class Pkcs11RsaKeyServiceTests
         return new Pkcs11RsaKeyService(certificateProviderService, cryptoFunctionService, pkcs11InteropFactory,
             settings);
     }
-    
+
     // EncryptAsync Tests
 
     [Fact]
@@ -74,7 +74,7 @@ public class Pkcs11RsaKeyServiceTests
         var sut = InitializeService();
         Assert.Null(await sut.EncryptAsync(null));
     }
-    
+
     // DecryptAsync Tests
 
     [Fact]
@@ -194,7 +194,8 @@ public class Pkcs11RsaKeyServiceTests
         {
             settings.RsaKey = new KeyConnectorSettings.RsaKeySettings
             {
-                Pkcs11Provider = "yubihsm", Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
+                Pkcs11Provider = "yubihsm",
+                Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
             };
             interopFactory.LoadPkcs11Library(default, default).ReturnsForAnyArgs(library);
         });
@@ -223,7 +224,8 @@ public class Pkcs11RsaKeyServiceTests
         {
             settings.RsaKey = new KeyConnectorSettings.RsaKeySettings
             {
-                Pkcs11Provider = "yubihsm", Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
+                Pkcs11Provider = "yubihsm",
+                Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
             };
             interopFactory.LoadPkcs11Library(default, default).ReturnsForAnyArgs(library);
         });
@@ -327,7 +329,7 @@ public class Pkcs11RsaKeyServiceTests
         var sut = InitializeService();
         Assert.Null(await sut.DecryptAsync(null));
     }
-    
+
     // SignAsync Tests
 
     [Fact]
@@ -439,7 +441,8 @@ public class Pkcs11RsaKeyServiceTests
         {
             settings.RsaKey = new KeyConnectorSettings.RsaKeySettings
             {
-                Pkcs11Provider = "yubihsm", Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
+                Pkcs11Provider = "yubihsm",
+                Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
             };
             interopFactory.LoadPkcs11Library(default, default).ReturnsForAnyArgs(library);
         });
@@ -468,7 +471,8 @@ public class Pkcs11RsaKeyServiceTests
         {
             settings.RsaKey = new KeyConnectorSettings.RsaKeySettings
             {
-                Pkcs11Provider = "yubihsm", Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
+                Pkcs11Provider = "yubihsm",
+                Pkcs11SlotTokenSerialNumber = "chosenSerialNumber",
             };
             interopFactory.LoadPkcs11Library(default, default).ReturnsForAnyArgs(library);
         });

--- a/test/KeyConnector.Tests/ThrowawayTests.cs
+++ b/test/KeyConnector.Tests/ThrowawayTests.cs
@@ -1,4 +1,4 @@
-using Xunit;
+﻿using Xunit;
 
 namespace KeyConnector.Tests;
 


### PR DESCRIPTION
## 🎟️ Tracking

https://bitwarden.atlassian.net/browse/PM-38500

## 📔 Objective

Re-organization of flat services namespace structure into more functional split: CertificateProviders, Crypto, Pkcs11, RsaKey.
Decided to do it now, before adding test coverage, so we can better understand what belongs where and what is the coverage.

## 📸 Screenshots

<!-- Required for any UI changes; delete if not applicable. Use fixed width images for better display. -->
